### PR TITLE
Allow requesting --build=* instead of --build=missing, other updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Generate odrcore dependency tree
         id: odrcore-dependency-tree
         # github.event.inputs will be null when workflow is triggered by a push event. Include all dependents on push
-        if: ${{ github.event.inputs == null || github.event.inputs.build_dependants != "false" }}
+        if: ${{ github.event.inputs == null || github.event.inputs.build_dependants != 'false' }}
         shell: bash # bash shell needed to pipefail on error
         run: |
           conan graph info recipes/odrcore/all/conanfile.py --version=4.0.0 --profile:host=android-21-armv8 --format=json | tee odrcore-dependency-tree.json
@@ -86,7 +86,7 @@ jobs:
       - name: Generate odrcore dependency tree
         id: pdf2htmlex-dependency-tree
         # github.event.inputs will be null when workflow is triggered by a push event. Include all dependents on push
-        if: ${{ github.event.inputs == null || github.event.inputs.build_dependants != "false" }}
+        if: ${{ github.event.inputs == null || github.event.inputs.build_dependants != 'false' }}
         shell: bash # bash shell needed to pipefail on error
         run: |
           conan graph info recipes/pdf2htmlex/all/conanfile.py --version=0.18.8.rc1-20240619-git --profile:host=android-21-armv8 --format=json | tee pdf2htmlEX-dependency-tree.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,8 @@ jobs:
       # Generating graphs for both 21 and 23 would be more self-explanatory, but conan graph generation takes a few seconds.
       - name: Generate odrcore dependency tree
         id: odrcore-dependency-tree
-        if: ${{ github.event.inputs.build_dependants != "false" }}
+        # github.event.inputs will be null when workflow is triggered by a push event. Include all dependents on push
+        if: ${{ github.event.inputs == null || github.event.inputs.build_dependants != "false" }}
         shell: bash # bash shell needed to pipefail on error
         run: |
           conan graph info recipes/odrcore/all/conanfile.py --version=4.0.0 --profile:host=android-21-armv8 --format=json | tee odrcore-dependency-tree.json
@@ -84,7 +85,8 @@ jobs:
       # Once odrcore depends on pdf2htmlex, pdf2htmlEX-dependency-tree.json generation and usage can be removed
       - name: Generate odrcore dependency tree
         id: pdf2htmlex-dependency-tree
-        if: ${{ github.event.inputs.build_dependants != "false" }}
+        # github.event.inputs will be null when workflow is triggered by a push event. Include all dependents on push
+        if: ${{ github.event.inputs == null || github.event.inputs.build_dependants != "false" }}
         shell: bash # bash shell needed to pipefail on error
         run: |
           conan graph info recipes/pdf2htmlex/all/conanfile.py --version=0.18.8.rc1-20240619-git --profile:host=android-21-armv8 --format=json | tee pdf2htmlEX-dependency-tree.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,8 +75,7 @@ jobs:
       # Generating graphs for both 21 and 23 would be more self-explanatory, but conan graph generation takes a few seconds.
       - name: Generate odrcore dependency tree
         id: odrcore-dependency-tree
-        # github.event.inputs will be null when workflow is triggered by a push event. Include all dependents on push
-        if: ${{ github.event.inputs == null || github.event.inputs.build_dependants != 'false' }}
+        if: ${{ github.event.inputs.build_dependants != 'false' }}
         shell: bash # bash shell needed to pipefail on error
         run: |
           conan graph info recipes/odrcore/all/conanfile.py --version=4.0.0 --profile:host=android-21-armv8 --format=json | tee odrcore-dependency-tree.json
@@ -85,8 +84,7 @@ jobs:
       # Once odrcore depends on pdf2htmlex, pdf2htmlEX-dependency-tree.json generation and usage can be removed
       - name: Generate odrcore dependency tree
         id: pdf2htmlex-dependency-tree
-        # github.event.inputs will be null when workflow is triggered by a push event. Include all dependents on push
-        if: ${{ github.event.inputs == null || github.event.inputs.build_dependants != 'false' }}
+        if: ${{ github.event.inputs.build_dependants != 'false' }}
         shell: bash # bash shell needed to pipefail on error
         run: |
           conan graph info recipes/pdf2htmlex/all/conanfile.py --version=0.18.8.rc1-20240619-git --profile:host=android-21-armv8 --format=json | tee pdf2htmlEX-dependency-tree.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ on:
         type: boolean
         default: false
       build_dependants:
-        description: Parse conan dependency tree and build not just requested package, but also all dependants of it
+        description: Parse conan dependency tree and build not just the requested package, but also all dependants of it
         type: boolean
         default: true
       build_from_source:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           echo "graph_file=odrcore-dependency-tree.json" >> $GITHUB_OUTPUT
 
       # Once odrcore depends on pdf2htmlex, pdf2htmlEX-dependency-tree.json generation and usage can be removed
-      - name: Generate odrcore dependency tree
+      - name: Generate pdf2htmlex dependency tree
         id: pdf2htmlex-dependency-tree
         if: ${{ github.event.inputs.build_dependants != 'false' }}
         shell: bash # bash shell needed to pipefail on error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ on:
         description: Upload built packages to artifactory
         type: boolean
         default: false
+      build_from_source:
+        description: Build all dependencies from source (conan install --build=* instead of --build=missing)
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -161,8 +165,17 @@ jobs:
           restore-keys: |
             ${{ matrix.config.build_machine }}-${{ matrix.config.host_profile }}-
 
+      - name: Parse build from source option
+        id: build_from_source
+        run: |
+          if [ ${{ github.event.inputs.build_from_source }} == "true" ]; then
+            echo argument=--build=* >> $GITHUB_OUTPUT
+          else
+            echo argument=--build=missing >> $GITHUB_OUTPUT
+          fi
+
       - name: conan install
-        run: conan install ${{ matrix.package.conanfile }} --version ${{ matrix.package.version }} --build missing --profile:host ${{ matrix.config.host_profile }} --profile:build ubuntu
+        run: conan install ${{ matrix.package.conanfile }} --version ${{ matrix.package.version }} ${{ steps.build_from_source.outputs.argument }} --profile:host ${{ matrix.config.host_profile }} --profile:build ubuntu
       - name: conan source
         run: conan source ${{ matrix.package.conanfile }} --version ${{ matrix.package.version }}
       - name: conan build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Get requested packages and dependants from commits and workflow_dispatch inputs
         id: list-packages-with-dependents
-        run: python scripts/list_package_versions.py --dependency-graph ${{ steps.odrcore-dependency-tree.outputs.graph_file }} ${{ steps.pdf2htmlex.outputs.graph_file }}
+        run: python scripts/list_package_versions.py --dependency-graph ${{ steps.odrcore-dependency-tree.outputs.graph_file }} ${{ steps.pdf2htmlex-dependency-tree.outputs.graph_file }}
         env:
           GITHUB_EVENT: ${{ toJson(github.event) }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ on:
         type: boolean
         default: false
       build_dependants:
-        description: Parse conan dependency tree and build not just the requested package, but also all dependants of it
+        description: Parse conan dependency tree and build not just the requested package, but also all dependents of it
         type: boolean
         default: true
       build_from_source:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ on:
         description: Upload built packages to artifactory
         type: boolean
         default: false
+      build_dependants:
+        description: Parse conan dependency tree and build not just requested package, but also all dependants of it
+        type: boolean
+        default: true
       build_from_source:
         description: Build all dependencies from source (conan install --build=* instead of --build=missing)
         type: boolean
@@ -69,15 +73,26 @@ jobs:
       # Dependency graphs for android-21 and android-23 profiles are not identical.
       # android-21 has an extra openlibm dependency. Android ABI does not matter for dependency graph, as long as it's still Android.
       # Generating graphs for both 21 and 23 would be more self-explanatory, but conan graph generation takes a few seconds.
-      - run: conan graph info recipes/odrcore/all/conanfile.py --version=4.0.0 --profile:host=android-21-armv8 --format=json | tee odrcore-dependency-tree.json
+      - name: Generate odrcore dependency tree
+        id: odrcore-dependency-tree
+        if: ${{ github.event.inputs.build_dependants != "false" }}
         shell: bash # bash shell needed to pipefail on error
+        run: |
+          conan graph info recipes/odrcore/all/conanfile.py --version=4.0.0 --profile:host=android-21-armv8 --format=json | tee odrcore-dependency-tree.json
+          echo "graph_file=odrcore-dependency-tree.json" >> $GITHUB_OUTPUT
+
       # Once odrcore depends on pdf2htmlex, pdf2htmlEX-dependency-tree.json generation and usage can be removed
-      - run: conan graph info recipes/pdf2htmlex/all/conanfile.py --version=0.18.8.rc1-20240619-git --profile:host=android-21-armv8 --format=json | tee pdf2htmlEX-dependency-tree.json
+      - name: Generate odrcore dependency tree
+        id: pdf2htmlex-dependency-tree
+        if: ${{ github.event.inputs.build_dependants != "false" }}
         shell: bash # bash shell needed to pipefail on error
+        run: |
+          conan graph info recipes/pdf2htmlex/all/conanfile.py --version=0.18.8.rc1-20240619-git --profile:host=android-21-armv8 --format=json | tee pdf2htmlEX-dependency-tree.json
+          echo "graph_file=pdf2htmlEX-dependency-tree.json" >> $GITHUB_OUTPUT
 
       - name: Get requested packages and dependants from commits and workflow_dispatch inputs
         id: list-packages-with-dependents
-        run: python scripts/list_package_versions.py --dependency-graph odrcore-dependency-tree.json pdf2htmlEX-dependency-tree.json
+        run: python scripts/list_package_versions.py --dependency-graph ${{ steps.odrcore-dependency-tree.outputs.graph_file }} ${{ steps.pdf2htmlex.outputs.graph_file }}
         env:
           GITHUB_EVENT: ${{ toJson(github.event) }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: build
 
 on:
   push:
+    paths:
+      - 'recipes/**'
   workflow_dispatch:
     inputs:
       package_name:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test Android
 
 on:
   push:
+    paths:
+      - 'recipes/**'
   workflow_dispatch:
     inputs:
       package_name:

--- a/scripts/emulator_matrix_generator.py
+++ b/scripts/emulator_matrix_generator.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-from pprint import pprint
 
 
 def main():
@@ -36,11 +35,12 @@ def main():
                     matrix.append({
                         "emulator_api_level": emulator_api_level,
                         "build_api_level": build_api_level,
+                        "api_type_target": api_type_target,
                         "arch": arch,
-                        "api_type_target": api_type_target
                     })
 
-    pprint(matrix)
+    for i in matrix:
+        print('-', i)
 
     gh_output = os.environ.get('GITHUB_OUTPUT')
     if gh_output:

--- a/scripts/list_package_versions.py
+++ b/scripts/list_package_versions.py
@@ -106,7 +106,7 @@ def main():
                              "$ENV[GITHUB_EVENT][inputs][package_version]."
                              "Specify 'newest' or leave empty to request the newest version. "
                              "Specify 'all' to request all versions.")
-    parser.add_argument("--dependency-graph", nargs='+', dest="CONAN_DEPENDENCY_GRAPH.json",
+    parser.add_argument("--dependency-graph", nargs='*', dest="CONAN_DEPENDENCY_GRAPH.json",
                         help="Used to calculate downstream dependents of requested packages")
 
     args = parser.parse_args()


### PR DESCRIPTION
Since we're having the issue of borked zlib package in artifactory, I've had to add the functionality to build all packages from source during conan install. This way zlib would be rebuilt and re-uoploaded to artifactory.

Current zlib issue:
```
zlib/1.3.1: Retrieving package a1706140403ecce58ad5f92ac00d87f712217671 from remote 'odr' 
zlib/1.3.1: ERROR: Exception while getting package: a1706140403ecce58ad5f92ac00d87f712217671
zlib/1.3.1: ERROR: Exception: <class 'conans.errors.ConanException'> Corrupted zlib/1.3.1:a1706140403ecce58ad5f92ac00d87f712217671 in 'odr' remote: no conanmanifest.txt
ERROR: Corrupted zlib/1.3.1:a1706140403ecce58ad5f92ac00d87f712217671 in 'odr' remote: no conanmanifest.txt
```

There are other changes in this update.

1) I came to the conclusion that building all dependents may not be needed at all times, so I've added a workflow_dispatch input to skip dependency tree parsing. Also, just so we're clear, and correct me if I'm wrong with the terminology:
- dependency is another package, on which this package depends on
- dependent is another package, which depends on this package

2) on push triggered workflows will only be triggered when actual recipes are modified (`on: push: paths: 'recipes/**'`). Previously we used to generate empty package matrix

3) emulator matrix generator to format output syntax in such a way, that the output text could be copy-pasted into workflow as-is. It still works as an action step too.


