### PR TITLE
Ordcore/1.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,25 +118,6 @@ jobs:
           - { build_machine: ubuntu-22.04, host_profile: android-21-armv7, ndk_version: 26.3.11579264 }
           - { build_machine: ubuntu-22.04, host_profile: android-21-x86, ndk_version: 26.3.11579264 }
           - { build_machine: ubuntu-22.04, host_profile: android-21-x86_64, ndk_version: 26.3.11579264 }
-        # Known not working build configurations
-        # Would be cool to actually solve odrcore/1.0.0 for Android
-        exclude:
-          - package: { "package_reference": "odrcore/1.0.0", "package": "odrcore", "version": "1.0.0", "conanfile": "recipes/odrcore/all/conanfile.py", "test_conanfile": "recipes/odrcore/all/test_package/conanfile.py" }
-            config: { build_machine: ubuntu-22.04, host_profile: android-23-armv8, ndk_version: 26.3.11579264 }
-          - package: { "package_reference": "odrcore/1.0.0", "package": "odrcore", "version": "1.0.0", "conanfile": "recipes/odrcore/all/conanfile.py", "test_conanfile": "recipes/odrcore/all/test_package/conanfile.py" }
-            config: { build_machine: ubuntu-22.04, host_profile: android-23-armv7, ndk_version: 26.3.11579264 }
-          - package: { "package_reference": "odrcore/1.0.0", "package": "odrcore", "version": "1.0.0", "conanfile": "recipes/odrcore/all/conanfile.py", "test_conanfile": "recipes/odrcore/all/test_package/conanfile.py" }
-            config: { build_machine: ubuntu-22.04, host_profile: android-23-x86, ndk_version: 26.3.11579264 }
-          - package: { "package_reference": "odrcore/1.0.0", "package": "odrcore", "version": "1.0.0", "conanfile": "recipes/odrcore/all/conanfile.py", "test_conanfile": "recipes/odrcore/all/test_package/conanfile.py" }
-            config: { build_machine: ubuntu-22.04, host_profile: android-23-x86_64, ndk_version: 26.3.11579264 }
-          - package: { "package_reference": "odrcore/1.0.0", "package": "odrcore", "version": "1.0.0", "conanfile": "recipes/odrcore/all/conanfile.py", "test_conanfile": "recipes/odrcore/all/test_package/conanfile.py" }
-            config: { build_machine: ubuntu-22.04, host_profile: android-21-armv8, ndk_version: 26.3.11579264 }
-          - package: { "package_reference": "odrcore/1.0.0", "package": "odrcore", "version": "1.0.0", "conanfile": "recipes/odrcore/all/conanfile.py", "test_conanfile": "recipes/odrcore/all/test_package/conanfile.py" }
-            config: { build_machine: ubuntu-22.04, host_profile: android-21-armv7, ndk_version: 26.3.11579264 }
-          - package: { "package_reference": "odrcore/1.0.0", "package": "odrcore", "version": "1.0.0", "conanfile": "recipes/odrcore/all/conanfile.py", "test_conanfile": "recipes/odrcore/all/test_package/conanfile.py" }
-            config: { build_machine: ubuntu-22.04, host_profile: android-21-x86, ndk_version: 26.3.11579264 }
-          - package: { "package_reference": "odrcore/1.0.0", "package": "odrcore", "version": "1.0.0", "conanfile": "recipes/odrcore/all/conanfile.py", "test_conanfile": "recipes/odrcore/all/test_package/conanfile.py" }
-            config: { build_machine: ubuntu-22.04, host_profile: android-21-x86_64, ndk_version: 26.3.11579264 }
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/recipes/odrcore/all/conandata.yml
+++ b/recipes/odrcore/all/conandata.yml
@@ -37,6 +37,9 @@ patches:
     - patch_file: "patches/1.0.0-0001-fix-cmake-install.patch"
       patch_description: "Fix header install in CMakeLists.txt"
       patch_type: "conan"
+    - patch_file: "patches/1.0.0-0002-fix-cryptopp-cpu-features.patch"
+      patch_description: "Cryptopp expects cpu-features.h and .c to be in the source dir, prepare them"
+      patch_type: "conan"
   "2.0.0":
     - patch_file: "patches/2.0.0-0001-fix-cmake-uchardet.patch"
       patch_description: "Fix broken dependency in CMakeLists.txt"

--- a/recipes/odrcore/all/conandata.yml
+++ b/recipes/odrcore/all/conandata.yml
@@ -37,7 +37,10 @@ patches:
     - patch_file: "patches/1.0.0-0001-fix-cmake-install.patch"
       patch_description: "Fix header install in CMakeLists.txt"
       patch_type: "conan"
-    - patch_file: "patches/1.0.0-0002-fix-cryptopp-cpu-features.patch"
+    - patch_file: "patches/1.0.0-0002-fix-glog-stacktrace-misdetection.patch"
+      patch_description: "Glog checks if execinfo.h is available and if it is - expects backtrace to be there, but backtrace only available from Android API 33"
+      patch_type: "conan"
+    - patch_file: "patches/1.0.0-0003-fix-cryptopp-cpu-features.patch"
       patch_description: "Cryptopp expects cpu-features.h and .c to be in the source dir, prepare them"
       patch_type: "conan"
   "2.0.0":

--- a/recipes/odrcore/all/conandata.yml
+++ b/recipes/odrcore/all/conandata.yml
@@ -38,7 +38,7 @@ patches:
       patch_description: "Fix header install in CMakeLists.txt"
       patch_type: "conan"
     - patch_file: "patches/1.0.0-0002-fix-glog-stacktrace-misdetection.patch"
-      patch_description: "Glog checks if execinfo.h is available and if it is - expects backtrace to be there, but backtrace only available from Android API 33"
+      patch_description: "Glog checks if execinfo.h is available and if it is - expects backtrace to be there, but backtrace is only available from Android API 33"
       patch_type: "conan"
     - patch_file: "patches/1.0.0-0003-fix-cryptopp-cpu-features.patch"
       patch_description: "Cryptopp expects cpu-features.h and .c to be in the source dir, prepare them"

--- a/recipes/odrcore/all/patches/1.0.0-0002-fix-cryptopp-cpu-features.patch
+++ b/recipes/odrcore/all/patches/1.0.0-0002-fix-cryptopp-cpu-features.patch
@@ -1,0 +1,11 @@
+--- CMakeLists.txt
++++ CMakeLists.txt 2024-07-22 14:35:52.630000000 +0300
+@@ -82,6 +82,8 @@
+     FetchContent_GetProperties(cryptopp)
+     if(NOT cryptopp_POPULATED)
+         FetchContent_Populate(cryptopp)
++        file(COPY ${CMAKE_ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c DESTINATION ${cryptopp_SOURCE_DIR})
++        file(COPY ${CMAKE_ANDROID_NDK}/sources/android/cpufeatures/cpu-features.h DESTINATION ${cryptopp_SOURCE_DIR})
+         set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+         add_subdirectory(${cryptopp_SOURCE_DIR} ${cryptopp_BINARY_DIR} EXCLUDE_FROM_ALL)
+     endif()

--- a/recipes/odrcore/all/patches/1.0.0-0002-fix-cryptopp-cpu-features.patch
+++ b/recipes/odrcore/all/patches/1.0.0-0002-fix-cryptopp-cpu-features.patch
@@ -1,11 +1,13 @@
 --- CMakeLists.txt
-+++ CMakeLists.txt 2024-07-22 14:35:52.630000000 +0300
-@@ -82,6 +82,8 @@
++++ CMakeLists.txt 2024-07-22 14:56:00 +0300
+@@ -82,6 +82,10 @@
      FetchContent_GetProperties(cryptopp)
      if(NOT cryptopp_POPULATED)
          FetchContent_Populate(cryptopp)
-+        file(COPY ${CMAKE_ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c DESTINATION ${cryptopp_SOURCE_DIR})
-+        file(COPY ${CMAKE_ANDROID_NDK}/sources/android/cpufeatures/cpu-features.h DESTINATION ${cryptopp_SOURCE_DIR})
++        if (DEFINED CMAKE_ANDROID_NDK)
++            file(COPY ${CMAKE_ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c DESTINATION ${cryptopp_SOURCE_DIR})
++            file(COPY ${CMAKE_ANDROID_NDK}/sources/android/cpufeatures/cpu-features.h DESTINATION ${cryptopp_SOURCE_DIR})
++        endif (DEFINED CMAKE_ANDROID_NDK)
          set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
          add_subdirectory(${cryptopp_SOURCE_DIR} ${cryptopp_BINARY_DIR} EXCLUDE_FROM_ALL)
      endif()

--- a/recipes/odrcore/all/patches/1.0.0-0002-fix-glog-stacktrace-misdetection.patch
+++ b/recipes/odrcore/all/patches/1.0.0-0002-fix-glog-stacktrace-misdetection.patch
@@ -6,8 +6,8 @@
      FetchContent_Populate(glog)
 +    file(READ ${glog_SOURCE_DIR}/CMakeLists.txt GLOG_CMAKELISTS)
 +    string(REPLACE
-+            "set (HAVE_STACKTRACE 1)"
-+            "if (NOT DEFINED ANDROID)\nset (HAVE_STACKTRACE 1)\nendif(NOT DEFINED ANDROID)"
++            "check_include_file (execinfo.h HAVE_EXECINFO_H)"
++            "if(NOT ANDROID)\n check_include_file (execinfo.h HAVE_EXECINFO_H)\n endif()"
 +            GLOG_CMAKELISTS
 +            "${GLOG_CMAKELISTS}")
 +    file(WRITE ${glog_SOURCE_DIR}/CMakeLists.txt "${GLOG_CMAKELISTS}")

--- a/recipes/odrcore/all/patches/1.0.0-0002-fix-glog-stacktrace-misdetection.patch
+++ b/recipes/odrcore/all/patches/1.0.0-0002-fix-glog-stacktrace-misdetection.patch
@@ -1,0 +1,16 @@
+--- CMakeLists.txt
++++ CMakeLists.txt
+@@ -59,6 +59,13 @@
+ FetchContent_GetProperties(glog)
+ if(NOT glog_POPULATED)
+     FetchContent_Populate(glog)
++    file(READ ${glog_SOURCE_DIR}/CMakeLists.txt GLOG_CMAKELISTS)
++    string(REPLACE
++            "set (HAVE_STACKTRACE 1)"
++            "if (NOT DEFINED ANDROID)\nset (HAVE_STACKTRACE 1)\nendif(NOT DEFINED ANDROID)"
++            GLOG_CMAKELISTS
++            "${GLOG_CMAKELISTS}")
++    file(WRITE ${glog_SOURCE_DIR}/CMakeLists.txt "${GLOG_CMAKELISTS}")
+     set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+     add_subdirectory(${glog_SOURCE_DIR} ${glog_BINARY_DIR} EXCLUDE_FROM_ALL)
+ endif()

--- a/recipes/odrcore/all/patches/1.0.0-0003-fix-cryptopp-cpu-features.patch
+++ b/recipes/odrcore/all/patches/1.0.0-0003-fix-cryptopp-cpu-features.patch
@@ -1,13 +1,13 @@
 --- CMakeLists.txt
-+++ CMakeLists.txt 2024-07-22 14:56:00 +0300
-@@ -82,6 +82,10 @@
++++ CMakeLists.txt
+@@ -89,6 +89,10 @@
      FetchContent_GetProperties(cryptopp)
      if(NOT cryptopp_POPULATED)
          FetchContent_Populate(cryptopp)
 +        if (DEFINED CMAKE_ANDROID_NDK)
 +            file(COPY ${CMAKE_ANDROID_NDK}/sources/android/cpufeatures/cpu-features.c DESTINATION ${cryptopp_SOURCE_DIR})
 +            file(COPY ${CMAKE_ANDROID_NDK}/sources/android/cpufeatures/cpu-features.h DESTINATION ${cryptopp_SOURCE_DIR})
-+        endif (DEFINED CMAKE_ANDROID_NDK)
++        endif(DEFINED CMAKE_ANDROID_NDK)
          set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
          add_subdirectory(${cryptopp_SOURCE_DIR} ${cryptopp_BINARY_DIR} EXCLUDE_FROM_ALL)
      endif()


### PR DESCRIPTION
Couple patches to make odrcore/1.0.0 almost compile for Android. Once it compiles, a bunch of lines can be removed from build.yml matrix excludes.

1) NDK has this library called cpu-features. Cryptopp makes use of it. Older version of Cryptopp, used by odrcore/1.0.0, expects to find cpu-features.c and .h in the cryptopp source directory. This patch does exactly that - copies cpu-features library from NDK to cryptopp_SOURCE_DIR.

2) Glog checks if execinfo.h is available and then thinks that backtrace function is available too, but the function was added only on Android 33. Patch disables execinfo.h detection for Android.

What's missing is solving this error in [svm/Svm2Svg](https://github.com/opendocument-app/OpenDocument.core/blob/v1.0.0/src/svm/Svm2Svg.cpp#L733):
```
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: error: use of overloaded operator '-' is ambiguous (with operand types 'pos_type' (aka 'fpos<mbstate_t>') and 'std::int64_t' (aka 'long'))
        std::int64_t left = action.vl.length - (in.tellg() - start);
                                                ~~~~~~~~~~ ^ ~~~~~
/usr/local/lib/android/sdk/ndk/26.3.11579264/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/__ios/fpos.h:52:30: note: candidate function
  _LIBCPP_HIDE_FROM_ABI fpos operator-(streamoff __off) const {
                             ^
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(long long, long)
        std::int64_t left = action.vl.length - (in.tellg() - start);
                                                           ^
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(float, long)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(double, long)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(long double, long)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(int, long)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(long, long)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(long long, float)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(long long, double)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(long long, long double)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(long long, int)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(long long, long long)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(long long, __int128)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(long long, unsigned int)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(long long, unsigned long)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(long long, unsigned long long)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(long long, unsigned __int128)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(__int128, long)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(unsigned int, long)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(unsigned long, long)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(unsigned long long, long)
/home/runner/work/conan-odr-index/conan-odr-index/recipes/odrcore/all/src/src/svm/Svm2Svg.cpp:733:60: note: built-in candidate operator-(unsigned __int128, long)
```