### PR TITLE
Add odrcore/4.1.0

### DIFF
--- a/recipes/odrcore/all/conandata.yml
+++ b/recipes/odrcore/all/conandata.yml
@@ -31,6 +31,10 @@ sources:
     source:
       url: "https://github.com/opendocument-app/OpenDocument.core/archive/refs/tags/v4.0.0.tar.gz"
       sha256: "b2d671f34bf641d465dfaae9adefdcb4a6210d58a519594a182ba2839531435e"
+  "4.1.0":
+    source:
+      url: "https://github.com/opendocument-app/OpenDocument.core/archive/refs/tags/v4.1.0.tar.gz"
+      sha256: "3608b1ac4723881b88d6212420bc725a0d758360d97155c1a5919271ae8f3c79"
 
 patches:
   "1.0.0":

--- a/recipes/odrcore/config.yml
+++ b/recipes/odrcore/config.yml
@@ -15,3 +15,5 @@ versions:
     folder: "all"
   "4.0.0":
     folder: "all"
+  "4.1.0":
+    folder: "all"


### PR DESCRIPTION
Hey @andiwand , does 4.1.0 need any patches? I assume not, both patches from 4.0.0 are already applied to 4.1.0 source.