### PR TITLE
odrcore/5: expose ODR_CLI as `with_cli`

### DIFF
--- a/recipes/odrcore/5/conanfile.py
+++ b/recipes/odrcore/5/conanfile.py
@@ -25,6 +25,7 @@ class OpenDocumentCoreConan(ConanFile):
         "with_wvWare": [True, False],
         "with_libmagic": [True, False],
         "with_http_server": [True, False],
+        "with_cli": [True, False],
         "with_python": [True, False],
         "with_jni": [True, False],
         "bundle_assets": [True, False],
@@ -36,6 +37,7 @@ class OpenDocumentCoreConan(ConanFile):
         "with_wvWare": True,
         "with_libmagic": True,
         "with_http_server": True,
+        "with_cli": True,
         "with_python": False,
         "with_jni": False,
         "bundle_assets": True,
@@ -49,6 +51,9 @@ class OpenDocumentCoreConan(ConanFile):
         #   ODR_BUNDLE_ASSETS      -> 5.3.0 (assets were always installed before)
         #   ODR_WITH_HTTP_SERVER   -> 5.4.1 (cpp-httplib was a hard dependency)
         #   ODR_PYTHON / ODR_JNI   -> 5.7.0 (bindings did not exist before)
+        # ODR_CLI is far older than any of these, but only from 5.7.0 does the
+        # install step skip the cli targets it did not build - turning it off in
+        # an older core just breaks packaging.
         version = Version(self.version)
         if version < "5.1.0":
             del self.options.with_libmagic
@@ -57,6 +62,7 @@ class OpenDocumentCoreConan(ConanFile):
         if version < "5.4.1":
             del self.options.with_http_server
         if version < "5.7.0":
+            del self.options.with_cli
             del self.options.with_python
             del self.options.with_jni
         if self.settings.os == "Windows":
@@ -125,6 +131,9 @@ class OpenDocumentCoreConan(ConanFile):
         tc.variables["WITH_WVWARE"] = self.options.get_safe("with_wvWare", False)
         tc.variables["WITH_LIBMAGIC"] = self.options.get_safe("with_libmagic", False)
         tc.variables["ODR_WITH_HTTP_SERVER"] = self.options.get_safe("with_http_server", True)
+        # Consumers that only link the library (e.g. the mobile apps) can drop the
+        # cli tools, which otherwise get built and installed with the package.
+        tc.variables["ODR_CLI"] = self.options.get_safe("with_cli", True)
         tc.variables["ODR_PYTHON"] = self.options.get_safe("with_python", False)
         tc.variables["ODR_JNI"] = self.options.get_safe("with_jni", False)
         # Consumers that ship the third-party data files themselves and wire the


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Why

Follow-up to feedback from [OpenDocument.ios#125](https://github.com/opendocument-app/OpenDocument.ios/pull/125):

> `ODR_CLI=OFF` would be tidier but odrcore 5.5.0 installs the cli targets whether or not it built them — worth fixing upstream.

A consumer that only links the library — both mobile apps — still pays for `meta`, `translate`, `back_translate` and `server` being built and installed, because this recipe never passed `ODR_CLI` to CMake.

## What

`with_cli`, default `True`, wired to `ODR_CLI`. Gated off below 5.7.0 alongside the existing gates: older cores install the cli targets whether or not they built them, so turning it off there would just break packaging.

The core-side counterpart is [OpenDocument.core#620](https://github.com/opendocument-app/OpenDocument.core/pull/620), which adds the same option to core's own recipe and installs `server` with the rest of the tools instead of dropping it.